### PR TITLE
Update pysteps version & add LINDA model

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,8 @@ dependencies:
   - git
   - numpy
   - scipy
+  - scikit-image
+  - opencv
   - h5py
   - pillow
   - pysteps=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,6 @@ dependencies:
   - scipy
   - h5py
   - pillow
-  - pysteps=1.4
+  - pysteps=1.7
   - dask
   - pyfftw

--- a/fmippn/CHANGELOG.md
+++ b/fmippn/CHANGELOG.md
@@ -1,16 +1,33 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Currently this project DOES NOT adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2020-04-17
-### Added
-- Parameter for calculation domain ("spatial" or "spectral")
-- `scipy` to `environment.yml`
+## 2023-01-30
 
 ### Changed
+
+- Renamed pysteps `R_thr` argument to `precip_thr` (update in `pysteps`)
+- Formatted all python source code files with `black` formatter (default settings)
+
+### Added
+
+- Functionality to run LINDA model from pysteps
+- Model specific metadata to output HDF5 file `how` group
+- Configuration option to specify whether rain rates are transformed to dBR
+
+## 2020-04-17
+
+### Added
+
+- Parameter for calculation domain ("spatial" or "spectral")
+- `scipy` and `opencv` to `environment.yml`
+
+### Changed
+
 - Updated README.md
 - Configuration files can now be stored anywhere, as long as full path is used for `-c` parameter values
 - Updated requirement for `python` (Used to be `=3.7`, now is `>=3.7`)
@@ -19,36 +36,45 @@ Currently this project DOES NOT adhere to [Semantic Versioning](https://semver.o
 - `-t` is now shorthand for `--timestamp` command line argument
 
 ### Removed
+
 - References to version numbers from changelog, as they don't reflect the current situation anymore
 - Obsolete `--test` command line argument
 
 ## 2020-01-29
+
 ### Added
+
 - Folder for configuration files
 - Utility functions for generating a configuration json file
 - Parameters `NORAIN_VALUE` and `RAIN_THRESHOLD` for thresholding
 - MIT License
 
 ### Changed
+
 - Configurations are now read from json files
 - Updated default configuration based on Pysteps article (Pulkkinen et al. 2019)
 - Updated pysteps version to 1.1.1
 - `LOG_FOLDER`, `LOG_LEVEL` and `OUTPUT_PATH` configuration parameters are no longer included in output metadata
 
 ### Removed
+
 - Configuration parameters `DBZ_MIN`, `DBZ_THRESHOLD`, `R_MIN`, `R_THRESHOLD` (Replaced with new parameters).
 
 ### Fixed
+
 - Program tried to write a log file before logging was initialised, when program couldn't find a given configuration. Now program raises an error instead.
 - Input data is now thresholded properly
 - Now it is possible to output values in mm/h, even if calculations are done in dBZ
 
 ## 2019-12-20
+
 ### Added
+
 - New parametrisations and configurations for operational use
 - Usage and Configuration descriptions to readme
 
 ### Changed
+
 - Now `pystepsrc` file is tracked, previously it was ignored
 - Renamed "dev" parametrisation to "test"
 - Updated default parameters: now generates 25 ensemble members for up to 120 minutes
@@ -57,15 +83,19 @@ Currently this project DOES NOT adhere to [Semantic Versioning](https://semver.o
 - Improved markdown syntax usage in changelog and readme
 
 ### Removed
+
 - Parametrisations used in research
 
 ### Fixed
+
 - Dangerous default argument value in `utils.store_timeseries()`
 - Removed unused import from `utils`
 - Version tag links in changelog
 
 ## 2019-09-02
+
 ### Added
+
 - Changelog
 - New dependency: pysteps (1.0.0)
 - Now it is possible to set motion perturbation parameters
@@ -78,6 +108,7 @@ Currently this project DOES NOT adhere to [Semantic Versioning](https://semver.o
 - Added configuration for heavy rainfall event in Helsinki on 23 Aug 2019
 
 ### Changed
+
 - Renamed readme.md to README.md
 - Deterministic nowcast uses now extrapolation
 - Old deterministic nowcast is renamed as "unperturbed nowcast"
@@ -85,10 +116,13 @@ Currently this project DOES NOT adhere to [Semantic Versioning](https://semver.o
 - Edited "dev" and "verification" parameters a bit
 
 ### Removed
+
 - Extra dependencies that were unused or no longer needed
 
 ## 2019-05-06
+
 ### Added
+
 - New parameters: `SEED`, `ZR_A`, `ZR_B`, `SCALE_ZERO`, `SCALER`, `FIELD_VALUES`
 - Now it is possible to set random number generator seed via `SEED` parameter
 - Now R(Z)-relation coefficients _a_ and _b_ can be set via parameters `ZR_A` and `ZR_B`
@@ -99,8 +133,10 @@ Currently this project DOES NOT adhere to [Semantic Versioning](https://semver.o
 - Parameters `SEED` and `FIELD_VALUES` are stored in output file's metadata
 
 ### Changed
+
 - "Valid for" attribute in output file is now an integer (was: string)
 - `OUTPUT_TIME_FORMAT` parameter no longer affects the "Valid for" attribute
 
 ## 2019-01-22
+
 - First prototype version given to operational testing

--- a/fmippn/config/linda.json
+++ b/fmippn/config/linda.json
@@ -14,7 +14,7 @@
   "data_options": {
     "zr_a": 223,
     "zr_b": 1.53,
-    "rain_threshold": -10
+    "rain_threshold": 8
   },
   "motion_options": {},
   "nowcast_options": {

--- a/fmippn/config/linda.json
+++ b/fmippn/config/linda.json
@@ -1,0 +1,105 @@
+{
+  "data_source": {
+    "root_path": "/input",
+    "path_fmt": "",
+    "fn_pattern": "%Y%m%d%H%M_radar.rack.comp_CONF=HULEHENRI",
+    "fn_ext": "h5",
+    "importer": "opera_hdf5",
+    "timestep": 5,
+    "importer_kwargs": {
+      "gzipped": false,
+      "qty": "DBZH"
+    }
+  },
+  "data_options": {
+    "zr_a": 223,
+    "zr_b": 1.53,
+    "rain_threshold": -10
+  },
+  "motion_options": {},
+  "nowcast_options": {
+    "method_specific_options": {
+      "steps": {
+        "n_cascade_levels": 6,
+        "fft_method": "pyfftw",
+        "domain": "spectral",
+        "noise_method": "nonparametric",
+        "ar_order": 2,
+        "mask_method": "incremental"
+      },
+      "linda": {
+        "max_num_features": 25,
+        "feature_method": "domain",
+        "feature_kwargs": {},
+        "ari_order": 1,
+        "kernel_type": "anisotropic",
+        "localization_window_radius": null,
+        "errdist_window_radius": null,
+        "acf_window_radius": null,
+        "extrap_kwargs": {},
+        "pert_thrs": [
+          0.5,
+          1.0
+        ]
+      }
+    },
+    "kmperpixel": 1.0,
+    "timestep": 5,
+    "n_ens_members": 10,
+    "num_workers": 6,
+    "vel_pert_method": "bps",
+    "vel_pert_kwargs": {
+      "p_par": [
+        2.20837526,
+        0.33887032,
+        -2.48995355
+      ],
+      "p_perp": [
+        2.21722634,
+        0.32359621,
+        -2.57402761
+      ]
+    },
+    "seed": null,
+    "extrap_method": "semilagrangian"
+  },
+  "output_options": {
+    "path": "/output",
+    "store_motion": true,
+    "store_perturbed_motion": false,
+    "store_ensemble": true,
+    "store_deterministic": true,
+    "as_quantity": "DBZH",
+    "convert_to_dtype": "uint16",
+    "gain": 0.01,
+    "offset": -327.68,
+    "set_undetect_value_to": 0,
+    "set_nodata_value_to": 65535,
+    "write_leadtimes_separately": true,
+    "write_asap": true,
+    "use_old_format": false
+  },
+  "run_options": {
+    "leadtimes": 12,
+    "nowcast_timestep": 5,
+    "max_leadtime": 60,
+    "run_deterministic": true,
+    "run_ensemble": true,
+    "regenerate_perturbed_motion": false,
+    "num_prev_observations": 3,
+    "motion_method": "lucaskanade",
+    "nowcast_method": "linda",
+    "deterministic_method": "linda",
+    "forecast_as_quantity": "RATE",
+    "transform_to_dBR": false,
+    "steps_set_no_rain_to_value": 0
+  },
+  "callback_options": {
+    "tmp_folder": ""
+  },
+  "logging": {
+    "write_log": true,
+    "log_level": 10,
+    "log_folder": "/log"
+  }
+}

--- a/fmippn/odim_io.py
+++ b/fmippn/odim_io.py
@@ -140,7 +140,6 @@ def _write(data, filename, metadata, configuration, optype=None):
 
         # Common groups
         how_grp = outf["how"]
-        how_grp.attrs["domain"] = configuration["nowcast_options"]["domain"]
 
         # Write AMVU and AMVV datasets and add attributes
         if optype == "mot":
@@ -204,10 +203,6 @@ def _write(data, filename, metadata, configuration, optype=None):
             # FIXME: "nowcast_timestep" might not be constants, see above
             how_grp.attrs["nowcast_timestep"] = nowcast_timestep
             how_grp.attrs["max_leadtime"] = configuration["run_options"]["max_leadtime"]
-            default_cascade_levels = defaults["nowcast_options"]["n_cascade_levels"]
-            how_grp.attrs["n_cascade_levels"] = configuration["nowcast_options"].get(
-                "n_cascade_levels", default_cascade_levels
-            )
 
         # Write ensemble forecast timeseries in ODIM format
         elif optype == "ens":
@@ -243,9 +238,26 @@ def _write(data, filename, metadata, configuration, optype=None):
             # FIXME: "nowcast_timestep" might not be constants, see above
             how_grp.attrs["nowcast_timestep"] = nowcast_timestep
             how_grp.attrs["max_leadtime"] = configuration["run_options"]["max_leadtime"]
-            default_cascade_levels = defaults["nowcast_options"]["n_cascade_levels"]
-            how_grp.attrs["n_cascade_levels"] = configuration["nowcast_options"].get(
-                "n_cascade_levels", default_cascade_levels
-            )
+
+        if optype in ["det", "ens"]:
+            # Write model specific metadata into /how group
+            if configuration["run_options"]["nowcast_method"] == "steps":
+                how_grp.attrs["ensemble_nowcast_method"] = "steps"
+                how_grp.attrs["domain"] = configuration["nowcast_options"]["domain"]
+                default_cascade_levels = defaults["nowcast_options"]["n_cascade_levels"]
+                how_grp.attrs["n_cascade_levels"] = configuration[
+                    "nowcast_options"
+                ].get("n_cascade_levels", default_cascade_levels)
+            elif configuration["run_options"]["nowcast_method"] == "linda":
+                how_grp.attrs["ensemble_nowcast_method"] = "linda"
+                how_grp.attrs["feature_method"] = configuration["nowcast_options"][
+                    "feature_method"
+                ]
+                how_grp.attrs["ari_order"] = str(
+                    configuration["nowcast_options"]["ari_order"]
+                )
+                how_grp.attrs["max_num_features"] = str(
+                    configuration["nowcast_options"]["max_num_features"]
+                )
 
     return None

--- a/fmippn/odim_io.py
+++ b/fmippn/odim_io.py
@@ -2,6 +2,7 @@
 import os
 
 import h5py
+import numpy as np
 
 import utils
 from ppn_config import defaults
@@ -153,7 +154,10 @@ def _write(data, filename, metadata, configuration, optype=None):
             }
 
             amvu_grp = outf.create_group("/dataset1/data1")
-            amvu_grp.create_dataset("data", data=AMVU)
+            ds = amvu_grp.create_dataset("data", data=AMVU)
+            # Add attributes to dataset to display as image in hdfview
+            ds.attrs["CLASS"] = np.string_("IMAGE")
+            ds.attrs["IMAGE_VERSION"] = np.string_("1.2")
             amvu_what_grp = amvu_grp.create_group("what")
             amvu_what_grp.attrs["quantity"] = "AMVU"
             amvu_how_grp = amvu_grp.create_group("how")
@@ -161,7 +165,10 @@ def _write(data, filename, metadata, configuration, optype=None):
                 amvu_how_grp.attrs[key] = value
 
             amvv_grp = outf.create_group("/dataset1/data2")
-            amvv_grp.create_dataset("data", data=AMVV)
+            ds = amvv_grp.create_dataset("data", data=AMVV)
+            # Add attributes to dataset to display as image in hdfview
+            ds.attrs["CLASS"] = np.string_("IMAGE")
+            ds.attrs["IMAGE_VERSION"] = np.string_("1.2")
             amvv_what_grp = amvv_grp.create_group("what")
             amvv_what_grp.attrs["quantity"] = "AMVV"
             amvv_how_grp = amvv_grp.create_group("how")
@@ -181,7 +188,10 @@ def _write(data, filename, metadata, configuration, optype=None):
                 # Store data
                 ts_point = data[index, :, :]
                 data_grp = dset_grp.create_group("data1")
-                data_grp.create_dataset("data", data=ts_point)
+                ds = data_grp.create_dataset("data", data=ts_point)
+                # Add attributes to dataset to display as image in hdfview
+                ds.attrs["CLASS"] = np.string_("IMAGE")
+                ds.attrs["IMAGE_VERSION"] = np.string_("1.2")
 
                 # Store data/what group attributes
                 utils.store_odim_data_what_attrs(data_grp, metadata, scale_meta)
@@ -215,7 +225,10 @@ def _write(data, filename, metadata, configuration, optype=None):
                     # Store data
                     ts_point = data[eidx, index, :, :]
                     data_grp = dset_grp.create_group(f"data{eidx+1}")
-                    data_grp.create_dataset("data", data=ts_point)
+                    ds = data_grp.create_dataset("data", data=ts_point)
+                    # Add attributes to dataset to display as image in hdfview
+                    ds.attrs["CLASS"] = np.string_("IMAGE")
+                    ds.attrs["IMAGE_VERSION"] = np.string_("1.2")
 
                     # Store data/what group attributes
                     utils.store_odim_data_what_attrs(data_grp, metadata, scale_meta)

--- a/fmippn/ppn.py
+++ b/fmippn/ppn.py
@@ -385,14 +385,14 @@ def generate_pysteps_setup():
     zr_b = PD["data_options"]["zr_b"]
 
     if utils.quantity_is_dbzh(input_qty) and utils.quantity_is_rate(fct_qty):
-        r_thr = (r_thr / zr_a) ** (1. / zr_b)
-        nowcast_kwargs["R_thr"] = max(10.0 * np.log10(r_thr), 0)  #
+        r_thr = (r_thr / zr_a) ** (1.0 / zr_b)
+        nowcast_kwargs["precip_thr"] = max(10.0 * np.log10(r_thr), 0)  #
         log("info", 'Converted RATE rain_threshold to decibel units ("dBR").')
     elif utils.quantity_is_rate(input_qty) and utils.quantity_is_dbzh(fct_qty):
         r_thr = zr_a * r_thr ** zr_b
-        nowcast_kwargs["R_thr"] = r_thr
+        nowcast_kwargs["precip_thr"] = r_thr
     else:
-        nowcast_kwargs["R_thr"] = r_thr
+        nowcast_kwargs["precip_thr"] = r_thr
 
     PD["converted_rain_thr"] = r_thr  # DBZH or non-decibel RATE is used in thresholding
 

--- a/fmippn/ppn.py
+++ b/fmippn/ppn.py
@@ -813,8 +813,10 @@ def write_odim_output_separately(
 
     # Create /dataset1/data1 group and store dataset and attributes
     data_grp = dset_grp.create_group("data1")
-    data_grp.create_dataset("data", data=n_field)
-
+    ds = data_grp.create_dataset("data", data=n_field)
+    # Add attributes to dataset to display as image in hdfview
+    ds.attrs["CLASS"] = np.string_("IMAGE")
+    ds.attrs["IMAGE_VERSION"] = np.string_("1.2")
     # Store attributes in /dataset1/data1/what (offset, gain, nodata, undetect etc)
     utils.store_odim_data_what_attrs(data_grp, metadata, store_meta)
 
@@ -934,7 +936,10 @@ def write_to_file(startdate, gen_output, nc_fname, metadata=None):
                     ens_grp = outf["member-{:0>2}".format(eidx)]
                 except KeyError:
                     ens_grp = outf.create_group("member-{:0>2}".format(eidx))
-                ens_grp.create_dataset("motion", data=ensemble_motion[eidx])
+                ds = ens_grp.create_dataset("motion", data=ensemble_motion[eidx])
+                # Add attributes to dataset to display as image in hdfview
+                ds.attrs["CLASS"] = np.string_("IMAGE")
+                ds.attrs["IMAGE_VERSION"] = np.string_("1.2")
 
         if deterministic is not None and output_options["store_deterministic"]:
             det_grp = outf.create_group("deterministic")
@@ -947,7 +952,10 @@ def write_to_file(startdate, gen_output, nc_fname, metadata=None):
             )
 
         if output_options["store_motion"]:
-            outf.create_dataset("motion", data=motion_field)
+            ds = outf.create_dataset("motion", data=motion_field)
+            # Add attributes to dataset to display as image in hdfview
+            ds.attrs["CLASS"] = np.string_("IMAGE")
+            ds.attrs["IMAGE_VERSION"] = np.string_("1.2")
 
         meta = outf.create_group("meta")
         # configuration "OUTPUT_TIME_FORMAT" is removed, new output uses ODIM standard

--- a/fmippn/ppn.py
+++ b/fmippn/ppn.py
@@ -28,6 +28,7 @@ import odim_io
 PD = dict()
 PD_callback = dict()
 
+
 def run(timestamp=None, config=None, **kwargs):
     """Main function for FMI-PPN.
 
@@ -43,8 +44,10 @@ def run(timestamp=None, config=None, **kwargs):
 
     PD.update(ppn_config.get_config(config))
 
-    initialise_logging(log_folder=PD["logging"]["log_folder"],
-                       log_fname="ppn-{:%Y%m%d}.log".format(dt.datetime.utcnow()))
+    initialise_logging(
+        log_folder=PD["logging"]["log_folder"],
+        log_fname="ppn-{:%Y%m%d}.log".format(dt.datetime.utcnow()),
+    )
 
     log("info", "Program starting.")
     log("debug", "Start setup")
@@ -61,7 +64,7 @@ def run(timestamp=None, config=None, **kwargs):
 
     PD["startdate"] = startdate
     PD["config"] = config
-        
+
     if nc_fname is None:
         nc_fname = "nc_{:%Y%m%d%H%M}.h5".format(startdate)
         nc_fname_templ = "{date:%Y%m%d%H%M}_radar.fmippn.{tag}_conf={config}.h5"
@@ -85,14 +88,20 @@ def run(timestamp=None, config=None, **kwargs):
     output_options = PD["output_options"]
 
     # Output filenames
-    motion_output_fname = output_options["path"].joinpath(nc_fname_templ.format(date=startdate, tag="motion", config=config))
-    ensemble_output_fname = output_options["path"].joinpath(nc_fname_templ.format(date=startdate, tag="ens", config=config))
-    determ_output_fname = output_options["path"].joinpath(nc_fname_templ.format(date=startdate, tag="det", config=config))
+    motion_output_fname = output_options["path"].joinpath(
+        nc_fname_templ.format(date=startdate, tag="motion", config=config)
+    )
+    ensemble_output_fname = output_options["path"].joinpath(
+        nc_fname_templ.format(date=startdate, tag="ens", config=config)
+    )
+    determ_output_fname = output_options["path"].joinpath(
+        nc_fname_templ.format(date=startdate, tag="det", config=config)
+    )
 
     # pysteps callback output folder setup
     if run_options["run_ensemble"] and output_options["write_leadtimes_separately"]:
         PD["callback_options"]["tmp_folder"].mkdir(parents=True, exist_ok=True)
-        
+
     log("debug", "Setup finished")
 
     # NOWCASTING
@@ -106,7 +115,9 @@ def run(timestamp=None, config=None, **kwargs):
 
     if datasource["importer"] in {"opera_hdf5", "odim_hdf5"}:
         input_quantity = datasource["importer_kwargs"]["qty"]
-        odim_metadata = utils.get_odim_attrs_from_input(input_files[0][-1])  # input_files is a tuple of two lists
+        odim_metadata = utils.get_odim_attrs_from_input(
+            input_files[0][-1]
+        )  # input_files is a tuple of two lists
         data_undetect = utils.get_odim_data_undetect(input_files[0][-1], input_quantity)
     else:
         # Cannot read ODIM metadata from non-ODIM files (.pgm)
@@ -124,8 +135,8 @@ def run(timestamp=None, config=None, **kwargs):
     observations, obs_metadata = read_observations(input_files, datasource, importer)
 
     # Save obs_metadata in callback function (global dictionary)
-    PD_callback['obs_metadata'] = obs_metadata
-    
+    PD_callback["obs_metadata"] = obs_metadata
+
     projection_meta = {
         "projstr": obs_metadata["projection"],
         "x1": obs_metadata["x1"],
@@ -147,9 +158,13 @@ def run(timestamp=None, config=None, **kwargs):
 
     # TODO: Convert motion field timestep, if needed?
 
-    if output_options.get("store_motion", False) and output_options.get("write_asap", False):
+    if output_options.get("store_motion", False) and output_options.get(
+        "write_asap", False
+    ):
         log("info", "write_asap requested, writing motion field now...")
-        odim_io.write_motion_to_file(PD, motion_field, motion_output_fname, metadata=asap_meta)
+        odim_io.write_motion_to_file(
+            PD, motion_field, motion_output_fname, metadata=asap_meta
+        )
 
     # Regenerate ensemble motion
     if run_options.get("regenerate_perturbed_motion"):
@@ -158,32 +173,40 @@ def run(timestamp=None, config=None, **kwargs):
         log("info", "Regenerating ensemble motion fields...")
         ensemble_motion = regenerate_ensemble_motion(motion_field, nowcast_kwargs)
         log("info", "Finished regeneration.")
-        if output_options.get("store_perturbed_motion", False) and output_options.get("write_asap", False):
+        if output_options.get("store_perturbed_motion", False) and output_options.get(
+            "write_asap", False
+        ):
             raise NotImplementedError
     else:
         ensemble_motion = None
 
     # If seed is none, make a random seed.
     if PD["nowcast_options"].get("seed") is None:
-        PD["nowcast_options"]["seed"] = random.randrange(2**32-1)
+        PD["nowcast_options"]["seed"] = random.randrange(2 ** 32 - 1)
 
     if run_options.get("run_deterministic"):
-        deterministic, det_meta = generate_deterministic(observations[-1],
-                                                         motion_field,
-                                                         deterministic_nowcaster,
-                                                         metadata=obs_metadata)
-        if output_options.get("store_deterministic", False) and output_options.get("write_asap", False):
+        deterministic, det_meta = generate_deterministic(
+            observations[-1],
+            motion_field,
+            deterministic_nowcaster,
+            metadata=obs_metadata,
+        )
+        if output_options.get("store_deterministic", False) and output_options.get(
+            "write_asap", False
+        ):
             log("info", "write_asap requested, writing deterministic nowcast now...")
             _out, _out_meta = prepare_data_for_writing(deterministic)
             asap_meta["scale_meta"] = _out_meta
             asap_meta["startdate"] = startdate
             asap_meta["unit"] = det_meta["unit"]
-            
+
             if output_options.get("write_leadtimes_separately", False):
                 log("info", "separate output requested for deterministic nowcast")
-                write_deterministic_separate_odim_output(_out, asap_meta, _out_meta)                
+                write_deterministic_separate_odim_output(_out, asap_meta, _out_meta)
             else:
-                odim_io.write_deterministic_to_file(PD, _out, determ_output_fname, metadata=asap_meta)      
+                odim_io.write_deterministic_to_file(
+                    PD, _out, determ_output_fname, metadata=asap_meta
+                )
             # Release memory
             _out = None
             deterministic = None
@@ -195,24 +218,40 @@ def run(timestamp=None, config=None, **kwargs):
     if run_options.get("run_ensemble"):
         if output_options.get("write_leadtimes_separately", False):
             # Run forecast without saving it here, saving through callback function
-            log("debug", "Callback was requested, will skip saving regardless of settings")
-            nowcaster(observations, motion_field, PD["run_options"]["leadtimes"],
-                         **nowcast_kwargs)
+            log(
+                "debug",
+                "Callback was requested, will skip saving regardless of settings",
+            )
+            nowcaster(
+                observations,
+                motion_field,
+                PD["run_options"]["leadtimes"],
+                **nowcast_kwargs,
+            )
             ensemble_forecast = None
             ens_meta = dict()
             PD["ensemble_size"] = None
         else:
-            ensemble_forecast, ens_meta = generate(observations, motion_field, nowcaster,
-                                                nowcast_kwargs, metadata=obs_metadata)
+            ensemble_forecast, ens_meta = generate(
+                observations,
+                motion_field,
+                nowcaster,
+                nowcast_kwargs,
+                metadata=obs_metadata,
+            )
             PD["ensemble_size"] = ensemble_forecast.shape[0]
-        
-            if output_options.get("store_ensemble", False) and output_options.get("write_asap", False):
+
+            if output_options.get("store_ensemble", False) and output_options.get(
+                "write_asap", False
+            ):
                 log("info", "write_asap requested, writing ensemble nowcast now...")
                 _out, _out_meta = prepare_data_for_writing(ensemble_forecast)
                 asap_meta["scale_meta"] = _out_meta
                 asap_meta["startdate"] = startdate
                 asap_meta["unit"] = ens_meta["unit"]
-                odim_io.write_ensemble_to_file(PD, _out, ensemble_output_fname, metadata=asap_meta)
+                odim_io.write_ensemble_to_file(
+                    PD, _out, ensemble_output_fname, metadata=asap_meta
+                )
                 # Release memory
                 _out = None
                 ensemble_forecast = None
@@ -265,30 +304,42 @@ def run(timestamp=None, config=None, **kwargs):
             motion_meta = {
                 "projection": projection_meta,
             }
-            odim_io.write_motion_to_file(PD, motion_field, motion_output_fname, metadata=motion_meta)
-        if output_options.get("store_ensemble") and not output_options.get("write_leadtimes_separately"):
-            odim_io.write_ensemble_to_file(PD, ensemble_forecast, ensemble_output_fname, metadata=store_meta)
+            odim_io.write_motion_to_file(
+                PD, motion_field, motion_output_fname, metadata=motion_meta
+            )
+        if output_options.get("store_ensemble") and not output_options.get(
+            "write_leadtimes_separately"
+        ):
+            odim_io.write_ensemble_to_file(
+                PD, ensemble_forecast, ensemble_output_fname, metadata=store_meta
+            )
         if output_options.get("store_deterministic"):
-            odim_io.write_deterministic_to_file(PD, deterministic, determ_output_fname, metadata=store_meta)
+            odim_io.write_deterministic_to_file(
+                PD, deterministic, determ_output_fname, metadata=store_meta
+            )
         if output_options.get("store_perturbed_motion"):
             pass
 
     log("info", "Finished writing output to a file.")
     log("info", "Run complete. Exiting.")
-    
-def initialise_logging(log_folder='./', log_fname='ppn.log'):
+
+
+def initialise_logging(log_folder="./", log_fname="ppn.log"):
     """Wrapper for ppn_logger.config_logging() method. Does nothing if writing
     to log is not enabled."""
     if PD["logging"]["write_log"]:
         full_path = Path(log_folder).expanduser().resolve()
-        ppn_logger.config_logging(full_path / log_fname,
-                                  level=PD["logging"]["log_level"])
+        ppn_logger.config_logging(
+            full_path / log_fname, level=PD["logging"]["log_level"]
+        )
+
 
 def log(level, msg, *args, **kwargs):
     """Wrapper for ppn_logger. Function does nothing if writing to log is
     not enabled."""
     if PD["logging"]["write_log"]:
         ppn_logger.write_to_log(level, msg, *args, **kwargs)
+
 
 def importer_method(module="pysteps", **kwargs):
     """Wrapper for easily switching between modules which provide data importer
@@ -309,6 +360,7 @@ def importer_method(module="pysteps", **kwargs):
 
     raise ValueError("Unknown module {} for importer method".format(module))
 
+
 def optflow_method(module="pysteps", **kwargs):
     """Wrapper for easily switching between modules which provide optical flow
     methods.
@@ -328,6 +380,7 @@ def optflow_method(module="pysteps", **kwargs):
 
     raise ValueError("Unknown module {} for optical flow method".format(module))
 
+
 def nowcast_method(module="pysteps", **kwargs):
     """Wrapper for easily switching between modules which provide nowcasting
     methods.
@@ -342,10 +395,13 @@ def nowcast_method(module="pysteps", **kwargs):
     Raise ValueError for invalid `module` selectors.
     """
     if module == "pysteps":
-        return pysteps.nowcasts.get_method(PD["run_options"]["nowcast_method"], **kwargs)
+        return pysteps.nowcasts.get_method(
+            PD["run_options"]["nowcast_method"], **kwargs
+        )
     # Add more options here
 
     raise ValueError("Unknown module {} for nowcast method".format(module))
+
 
 def deterministic_method(module="pysteps", **kwargs):
     """Wrapper for easily switching between modules which provide deterministic
@@ -361,10 +417,13 @@ def deterministic_method(module="pysteps", **kwargs):
     Raise ValueError for invalid `module` selectors.
     """
     if module == "pysteps":
-        return pysteps.nowcasts.get_method(PD["run_options"]["deterministic_method"], **kwargs)
+        return pysteps.nowcasts.get_method(
+            PD["run_options"]["deterministic_method"], **kwargs
+        )
     # Add more options here
 
     raise ValueError("Unknown module {} for deterministic method".format(module))
+
 
 def generate_pysteps_setup():
     """Generate `nowcast_kwargs` objects that are suitable
@@ -403,16 +462,19 @@ def generate_pysteps_setup():
 
     return nowcast_kwargs
 
+
 def get_filelist(startdate, datasource):
     """Get a list of input file names"""
     try:
-        filelist = pysteps.io.find_by_date(startdate,
-                                           datasource["root_path"],
-                                           datasource["path_fmt"],
-                                           datasource["fn_pattern"],
-                                           datasource["fn_ext"],
-                                           datasource["timestep"],
-                                           num_prev_files=PD["run_options"]["num_prev_observations"])
+        filelist = pysteps.io.find_by_date(
+            startdate,
+            datasource["root_path"],
+            datasource["path_fmt"],
+            datasource["fn_pattern"],
+            datasource["fn_ext"],
+            datasource["timestep"],
+            num_prev_files=PD["run_options"]["num_prev_observations"],
+        )
     except OSError as pysteps_error:
         error_msg = "Failed to read input data!"
         log("error", f"OSError was raised: {error_msg}")
@@ -420,14 +482,15 @@ def get_filelist(startdate, datasource):
         raise OSError(error_msg) from pysteps_error
     return filelist
 
+
 def read_observations(filelist, datasource, importer):
     """Read observations from archives using pysteps methods. Also threshold
     the input data and (optionally) convert dBZ -> dBR based on configuration
     parameters."""
     # PGM files contain dBZ values
-    obs, _, metadata = pysteps.io.readers.read_timeseries(filelist,
-                                                          importer,
-                                                          **datasource["importer_kwargs"])
+    obs, _, metadata = pysteps.io.readers.read_timeseries(
+        filelist, importer, **datasource["importer_kwargs"]
+    )
 
     input_qty = PD["input_quantity"]
     fct_qty = PD["run_options"].get("forecast_as_quantity", input_qty)
@@ -437,21 +500,30 @@ def read_observations(filelist, datasource, importer):
     elif utils.quantity_is_rate(input_qty) and utils.quantity_is_dbzh(fct_qty):
         obs, metadata = rrate_to_dbz(obs, metadata)
 
-    obs, metadata = thresholding(obs, metadata, threshold=PD["converted_rain_thr"],
-                                 norain_value=PD["run_options"]["steps_set_no_rain_to_value"])
+    obs, metadata = thresholding(
+        obs,
+        metadata,
+        threshold=PD["converted_rain_thr"],
+        norain_value=PD["run_options"]["steps_set_no_rain_to_value"],
+    )
 
     if utils.quantity_is_rate(fct_qty):
         obs, metadata = transform_to_decibels(obs, metadata)
 
     return obs, metadata
 
+
 def dbz_to_rrate(data, metadata):
-    return pysteps.utils.conversion.to_rainrate(data, metadata, PD["data_options"]["zr_a"],
-                                                PD["data_options"]["zr_b"])
+    return pysteps.utils.conversion.to_rainrate(
+        data, metadata, PD["data_options"]["zr_a"], PD["data_options"]["zr_b"]
+    )
+
 
 def rrate_to_dbz(data, metadata):
-    return pysteps.utils.conversion.to_reflectivity(data, metadata, PD["data_options"]["zr_a"],
-                                                    PD["data_options"]["zr_b"])
+    return pysteps.utils.conversion.to_reflectivity(
+        data, metadata, PD["data_options"]["zr_a"], PD["data_options"]["zr_b"]
+    )
+
 
 def transform_to_decibels(data, metadata, inverse=False):
     """Transform data to decibel units. Assumes thresholded data.
@@ -485,9 +557,9 @@ def transform_to_decibels(data, metadata, inverse=False):
 
     return data, metadata
 
+
 def thresholding(data, metadata, threshold, norain_value, fill_nan=True):
-    """Set values under 'threshold' to 'norain_value'. Optionally replace np.nan with 'norain_value'.
-    """
+    """Set values under 'threshold' to 'norain_value'. Optionally replace np.nan with 'norain_value'."""
     if fill_nan:
         data[~np.isfinite(data)] = norain_value
     data[data < threshold] = norain_value
@@ -497,10 +569,12 @@ def thresholding(data, metadata, threshold, norain_value, fill_nan=True):
 
     return data, metadata
 
+
 def generate(observations, motion_field, nowcaster, nowcast_kwargs, metadata=None):
     """Generate ensemble nowcast using pysteps nowcaster."""
-    forecast = nowcaster(observations, motion_field, PD["run_options"]["leadtimes"],
-                         **nowcast_kwargs)
+    forecast = nowcaster(
+        observations, motion_field, PD["run_options"]["leadtimes"], **nowcast_kwargs
+    )
 
     if (metadata["unit"] == "mm/h") and (metadata["transform"] == "dB"):
         forecast, meta = transform_to_decibels(forecast, metadata, inverse=True)
@@ -536,12 +610,18 @@ def generate(observations, motion_field, nowcaster, nowcast_kwargs, metadata=Non
     rain_threshold = PD["out_rain_threshold"]
     norain_for_output = PD["out_norain_value"]
 
-    forecast, meta = thresholding(forecast, meta, threshold=rain_threshold,
-                                  norain_value=norain_for_output, fill_nan=False)
+    forecast, meta = thresholding(
+        forecast,
+        meta,
+        threshold=rain_threshold,
+        norain_value=norain_for_output,
+        fill_nan=False,
+    )
 
     if meta is None:
         meta = dict()
     return forecast, meta
+
 
 def _convert_for_output(value, out_qty):
     zr_a = PD["data_options"]["zr_a"]
@@ -558,7 +638,7 @@ def _convert_for_output(value, out_qty):
         # Z = 10 ** (dBZ / 10)
         value = 10 ** (value / 10)
         # R = (Z / zr_a) ** (1.0 / zr_b)
-        value = (value / zr_a) ** (1. / zr_b)
+        value = (value / zr_a) ** (1.0 / zr_b)
 
     elif utils.quantity_is_rate(in_qty) and utils.quantity_is_dbzh(out_qty):
         # Z = zr_a * R ** zr_b
@@ -568,15 +648,19 @@ def _convert_for_output(value, out_qty):
 
     return value
 
-def generate_deterministic(observations, motion_field, nowcaster, nowcast_kwargs=None,
-                           metadata=None):
+
+def generate_deterministic(
+    observations, motion_field, nowcaster, nowcast_kwargs=None, metadata=None
+):
     """Generate a deterministic nowcast using semilagrangian extrapolation"""
     # Extrapolation scheme doesn't use the same nowcast_kwargs as steps
     if nowcast_kwargs is None:
         nowcast_kwargs = dict()
-    forecast, meta = generate(observations, motion_field, nowcaster, nowcast_kwargs,
-                              metadata)
+    forecast, meta = generate(
+        observations, motion_field, nowcaster, nowcast_kwargs, metadata
+    )
     return forecast, meta
+
 
 def regenerate_ensemble_motion(motion_field, nowcast_kwargs):
     """Generate motion perturbations the same way as pysteps.nowcasts.steps function.
@@ -584,7 +668,7 @@ def regenerate_ensemble_motion(motion_field, nowcast_kwargs):
     This is a workaround for obtaining perturbed motion fields from steps
     calculations, as pysteps doesn't currently give them as output. (2019-09-02)
     """
-    pixelsperkm = 1./nowcast_kwargs["kmperpixel"]
+    pixelsperkm = 1.0 / nowcast_kwargs["kmperpixel"]
     timestep = nowcast_kwargs["timestep"]
     pert_params = nowcast_kwargs["vel_pert_kwargs"]
 
@@ -606,26 +690,33 @@ def regenerate_ensemble_motion(motion_field, nowcast_kwargs):
 
     ensemble_motions = []
     for i, random_state in enumerate(randgen_motion):
-        init_perturbations = pysteps.noise.motion.initialize_bps(motion_field,
-                                                                 pixelsperkm,
-                                                                 timestep,
-                                                                 p_par=pert_params["p_par"],
-                                                                 p_perp=pert_params["p_perp"],
-                                                                 randstate=random_state)
-        perturbations = pysteps.noise.motion.generate_bps(init_perturbations, timestep*(i+1))
+        init_perturbations = pysteps.noise.motion.initialize_bps(
+            motion_field,
+            pixelsperkm,
+            timestep,
+            p_par=pert_params["p_par"],
+            p_perp=pert_params["p_perp"],
+            randstate=random_state,
+        )
+        perturbations = pysteps.noise.motion.generate_bps(
+            init_perturbations, timestep * (i + 1)
+        )
         perturbed = motion_field + perturbations
         ensemble_motions.append(perturbed)
 
     return ensemble_motions
 
+
 def prepare_data_for_writing(forecast):
     """Convert and scale ensemble and deterministic forecast data to uint16 type"""
     # Actual method moved to utils.py
-    return utils.prepare_data_for_writing(forecast,
-                                          options=PD["output_options"],
-                                          forecast_undetect=PD["out_norain_value"],
+    return utils.prepare_data_for_writing(
+        forecast,
+        options=PD["output_options"],
+        forecast_undetect=PD["out_norain_value"],
+        forecast_nodata=None,
+    )
 
-                                          forecast_nodata=None)
 
 def get_timesteps():
     """Return the nowcast timestep if it is regular"""
@@ -634,50 +725,58 @@ def get_timesteps():
 
 
 def write_deterministic_separate_odim_output(field, metadata, store_meta):
-    """Write deterministic forecast single dataset per file.
-    """
+    """Write deterministic forecast single dataset per file."""
 
     folder = PD["callback_options"]["tmp_folder"]
-    
-    for i in range(field.shape[0]):
-        timestep=PD["run_options"]["nowcast_timestep"]
-        timestamp = (PD["startdate"] + (i+1) * dt.timedelta(minutes=timestep)).strftime('%Y%m%d%H%M')
-        fname = f"{PD['startdate']:%Y%m%d%H%M}_{timestamp}_nclen={(i+1)*timestep:03}min_radar.fmippn.det_conf={PD['config']}.h5"
-        with h5py.File(folder.joinpath(fname), 'w') as f:
-            write_odim_output_separately(f, i, field[i,:,:], metadata, store_meta, fc_type="det")
 
+    for i in range(field.shape[0]):
+        timestep = PD["run_options"]["nowcast_timestep"]
+        timestamp = (
+            PD["startdate"] + (i + 1) * dt.timedelta(minutes=timestep)
+        ).strftime("%Y%m%d%H%M")
+        fname = f"{PD['startdate']:%Y%m%d%H%M}_{timestamp}_nclen={(i+1)*timestep:03}min_radar.fmippn.det_conf={PD['config']}.h5"
+        with h5py.File(folder.joinpath(fname), "w") as f:
+            write_odim_output_separately(
+                f, i, field[i, :, :], metadata, store_meta, fc_type="det"
+            )
 
 
 def cb_nowcast(field):
-    """Callback function for pysteps.                                             
+    """Callback function for pysteps.
     Store calculated fields to their own hdf5 files.
     """
     # Count calls from pysteps, used for calculating the timestamp.
     n_timestep = cb_nowcast.counter
     cb_nowcast.counter += 1
-    
-    timestep=PD["run_options"]["nowcast_timestep"]
-    timestamp = (PD["startdate"] + cb_nowcast.counter * dt.timedelta(minutes=timestep)).strftime('%Y%m%d%H%M')
+
+    timestep = PD["run_options"]["nowcast_timestep"]
+    timestamp = (
+        PD["startdate"] + cb_nowcast.counter * dt.timedelta(minutes=timestep)
+    ).strftime("%Y%m%d%H%M")
     folder = PD["callback_options"]["tmp_folder"]
 
     # Process data to wanted output format
     field, metadata, store_meta = process_callback_output(field)
-    
+
     # Store each ensemble member separately
     for i in range(field.shape[0]):
-        member=i+1
+        member = i + 1
         fname = f"{PD['startdate']:%Y%m%d%H%M}_{timestamp}_nclen={cb_nowcast.counter*timestep:03}min_radar.fmippn.ens_conf={PD['config']}_ensmem={member}.h5"
-        with h5py.File(folder.joinpath(fname), 'w') as f:
+        with h5py.File(folder.joinpath(fname), "w") as f:
 
-            write_odim_output_separately(f, n_timestep, field[i,:,:], metadata, store_meta, fc_type="ens")
-            
-            
-# Initialize callback function counter                                                                                                    
+            write_odim_output_separately(
+                f, n_timestep, field[i, :, :], metadata, store_meta, fc_type="ens"
+            )
+
+
+# Initialize callback function counter
 cb_nowcast.counter = 0
 
 
-def write_odim_output_separately(f, n_timestep, n_field, metadata, store_meta, fc_type=False):
-    """    Write single dataset per ODIM HDF5 file.
+def write_odim_output_separately(
+    f, n_timestep, n_field, metadata, store_meta, fc_type=False
+):
+    """Write single dataset per ODIM HDF5 file.
 
     Input:
         f -- h5py file object
@@ -685,36 +784,38 @@ def write_odim_output_separately(f, n_timestep, n_field, metadata, store_meta, f
         n_field -- leadtime field
         metadata -- dictionary containing nowcast metadata
         store_meta -- dictionary containing output metadata (gain, offset etc.)
-    
+
     """
-    
+
     # Copy /how, /what and /where groups from input data
-    utils.copy_odim_attributes(PD["odim_metadata"],f)
-    
+    utils.copy_odim_attributes(PD["odim_metadata"], f)
+
     # Create /dataset1 group and store attributes
-    dset_grp=f.create_group("/dataset1")
-    utils.store_odim_dset_attrs(dset_grp, n_timestep, PD["startdate"], PD["run_options"]["nowcast_timestep"])
+    dset_grp = f.create_group("/dataset1")
+    utils.store_odim_dset_attrs(
+        dset_grp, n_timestep, PD["startdate"], PD["run_options"]["nowcast_timestep"]
+    )
 
     # Create /dataset1/data1 group and store dataset and attributes
-    data_grp=dset_grp.create_group("data1")
-    data_grp.create_dataset("data",data=n_field)
+    data_grp = dset_grp.create_group("data1")
+    data_grp.create_dataset("data", data=n_field)
 
     # Store attributes in /dataset1/data1/what (offset, gain, nodata, undetect etc)
     utils.store_odim_data_what_attrs(data_grp, metadata, store_meta)
-            
-    #Store PPN specific metadata into /how group
-    how_grp=f["/how"]
+
+    # Store PPN specific metadata into /how group
+    how_grp = f["/how"]
     how_grp.attrs["zr_a"] = PD["data_options"]["zr_a"]
     how_grp.attrs["zr_b"] = PD["data_options"]["zr_b"]
     how_grp.attrs["num_timesteps"] = PD["run_options"]["leadtimes"]
     how_grp.attrs["nowcast_timestep"] = PD["run_options"]["nowcast_timestep"]
     how_grp.attrs["max_leadtime"] = PD["run_options"]["max_leadtime"]
 
-    #Store ensemble forecast specific metadata
+    # Store ensemble forecast specific metadata
     if fc_type == "ens":
         how_grp.attrs["ensemble_size"] = PD["nowcast_options"]["n_ens_members"]
         how_grp.attrs["seed"] = PD["nowcast_options"]["seed"]
-    
+
 
 def process_callback_output(forecast):
     """
@@ -722,8 +823,8 @@ def process_callback_output(forecast):
     """
 
     # Get metadata from PD_callback global dictionary
-    metadata = PD_callback['obs_metadata']
-    
+    metadata = PD_callback["obs_metadata"]
+
     if (metadata["unit"] == "mm/h") and (metadata["transform"] == "dB"):
         forecast, meta = transform_to_decibels(forecast, metadata, inverse=True)
     else:
@@ -738,7 +839,7 @@ def process_callback_output(forecast):
 
     elif utils.quantity_is_rate(out_qty) and metadata["unit"] == "dBZ":
         forecast, meta = dbz_to_rrate(forecast, meta)
-            # Might need to convert the norain value and threshold, too                        
+        # Might need to convert the norain value and threshold, too
     if "out_rain_threshold" not in PD:
         _rain_threshold = PD["data_options"].get("rain_threshold")
         PD["out_rain_threshold"] = _convert_for_output(_rain_threshold, out_qty)
@@ -753,12 +854,17 @@ def process_callback_output(forecast):
 
     rain_threshold = PD["out_rain_threshold"]
     norain_for_output = PD["out_norain_value"]
-    
-    forecast, meta = thresholding(forecast, meta, threshold=rain_threshold,
-                                  norain_value=norain_for_output, fill_nan=False)
+
+    forecast, meta = thresholding(
+        forecast,
+        meta,
+        threshold=rain_threshold,
+        norain_value=norain_for_output,
+        fill_nan=False,
+    )
 
     forecast, store_meta = prepare_data_for_writing(forecast)
-    
+
     if meta is None:
         meta = dict()
     return forecast, meta, store_meta
@@ -795,15 +901,17 @@ def write_to_file(startdate, gen_output, nc_fname, metadata=None):
     ensemble_forecast, ens_scale_meta = prepare_data_for_writing(ensemble_forecast)
     deterministic, det_scale_meta = prepare_data_for_writing(deterministic)
 
-    with h5py.File(output_options["path"].joinpath(nc_fname), 'w') as outf:
+    with h5py.File(output_options["path"].joinpath(nc_fname), "w") as outf:
         if ensemble_forecast is not None and output_options["store_ensemble"]:
             for eidx in range(PD["ensemble_size"]):
                 ens_grp = outf.create_group("member-{:0>2}".format(eidx))
-                utils.store_timeseries(ens_grp,
-                                       ensemble_forecast[eidx, :, :, :],
-                                       startdate,
-                                       timestep=nowcast_timestep,
-                                       metadata=ens_scale_meta)
+                utils.store_timeseries(
+                    ens_grp,
+                    ensemble_forecast[eidx, :, :, :],
+                    startdate,
+                    timestep=nowcast_timestep,
+                    metadata=ens_scale_meta,
+                )
 
         if ensemble_motion is not None and output_options["store_perturbed_motion"]:
             for eidx in range(PD["ensemble_size"]):
@@ -815,19 +923,25 @@ def write_to_file(startdate, gen_output, nc_fname, metadata=None):
 
         if deterministic is not None and output_options["store_deterministic"]:
             det_grp = outf.create_group("deterministic")
-            utils.store_timeseries(det_grp, deterministic, startdate,
-                                   timestep=nowcast_timestep,
-                                   metadata=det_scale_meta)
+            utils.store_timeseries(
+                det_grp,
+                deterministic,
+                startdate,
+                timestep=nowcast_timestep,
+                metadata=det_scale_meta,
+            )
 
         if output_options["store_motion"]:
             outf.create_dataset("motion", data=motion_field)
 
         meta = outf.create_group("meta")
         # configuration "OUTPUT_TIME_FORMAT" is removed, new output uses ODIM standard
-        meta.attrs["nowcast_started"] = dt.datetime.strftime(metadata["time_at_start"],
-                                                             "%Y-%m-%d %H:%M:%S")
-        meta.attrs["nowcast_ended"] = dt.datetime.strftime(metadata["time_at_end"],
-                                                           "%Y-%m-%d %H:%M:%S")
+        meta.attrs["nowcast_started"] = dt.datetime.strftime(
+            metadata["time_at_start"], "%Y-%m-%d %H:%M:%S"
+        )
+        meta.attrs["nowcast_ended"] = dt.datetime.strftime(
+            metadata["time_at_end"], "%Y-%m-%d %H:%M:%S"
+        )
         meta.attrs["nowcast_units"] = metadata.get("unit", "Unknown")
         meta.attrs["nowcast_seed"] = metadata.get("seed", "Unknown")
         meta.attrs["nowcast_init_time"] = dt.datetime.strftime(startdate, "%Y%m%d%H%M")
@@ -835,8 +949,10 @@ def write_to_file(startdate, gen_output, nc_fname, metadata=None):
         # Old configurations - may be used by postprocessing scripts
         old_style_configs = {
             # Method selections
-            #"DOMAIN": "fmi", # postprocessing defines this instead of reading it here
-            "VALUE_DOMAIN": "rrate" if PD["run_options"]["forecast_as_quantity"] == "RATE" else "dbz",  # Unused?
+            # "DOMAIN": "fmi", # postprocessing defines this instead of reading it here
+            "VALUE_DOMAIN": "rrate"
+            if PD["run_options"]["forecast_as_quantity"] == "RATE"
+            else "dbz",  # Unused?
             # Z-R conversion parameters
             "ZR_A": PD["data_options"]["zr_a"],  #
             "ZR_B": PD["data_options"]["zr_b"],  #
@@ -867,6 +983,6 @@ def write_to_file(startdate, gen_output, nc_fname, metadata=None):
 
     return None
 
-        
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run(test=True)

--- a/fmippn/ppn_config.py
+++ b/fmippn/ppn_config.py
@@ -280,7 +280,18 @@ defaults = {
                 "ar_order": 2,
                 "mask_method": "incremental",
             },
-            "linda": {},
+            "linda": {
+                "max_num_features": 25,
+                "feature_method": "shitomasi",
+                "feature_kwargs": {},
+                "ari_order": 1,
+                "kernel_type": "anisotropic",
+                "localization_window_radius": None,
+                "errdist_window_radius": None,
+                "acf_window_radius": None,
+                "extrap_kwargs": {},
+                "pert_thrs": (0.5, 1.0),
+            },
         },
         "vel_pert_method": "bps",  # pysteps default, requires kmperpixel to be set
         "vel_pert_kwargs": {
@@ -337,6 +348,7 @@ defaults = {
         "deterministic_method": "extrapolation",
         #
         "forecast_as_quantity": "DBZH",  # Input data is converted to this before nowcasting
+        "transform_to_dBR": True,  # Convert to decibel rain rate before nowcasting (only used if forecast_as_quantity is RATE)
         "steps_set_no_rain_to_value": -10,  # In forecast quantity units
     },
     # Used when writing ensemble nowcasts after each timestep with callback function

--- a/fmippn/ppn_config.py
+++ b/fmippn/ppn_config.py
@@ -282,7 +282,7 @@ defaults = {
             },
             "linda": {
                 "max_num_features": 25,
-                "feature_method": "shitomasi",
+                "feature_method": "domain",
                 "feature_kwargs": {},
                 "ari_order": 1,
                 "kernel_type": "anisotropic",

--- a/fmippn/ppn_config.py
+++ b/fmippn/ppn_config.py
@@ -250,7 +250,7 @@ defaults = {
         # Required parameters that need to be calculated or defined
         #"kmperpixel": # required for motion perturbation method (bps)
         #"timestep": # "Timestep" of MOTION VECTOR, get from input data
-        #"R_thr":  # must be in decibel units...
+        # "precip_thr":  # must be in decibel units...
     },
 
     "output_options": {

--- a/fmippn/ppn_config.py
+++ b/fmippn/ppn_config.py
@@ -32,8 +32,10 @@ def get_config(override_name=None):
     if override_name is not None:
         override_params = get_params(override_name)
         if not override_params:
-            no_config_found_msg = ("Couldn't find overriding parameters in "
-                                   "ppn_config. Key '{}' was unrecognised.").format(override_name)
+            no_config_found_msg = (
+                "Couldn't find overriding parameters in "
+                "ppn_config. Key '{}' was unrecognised."
+            ).format(override_name)
             raise ValueError(no_config_found_msg)
         for key, group in override_params.items():
             try:
@@ -41,7 +43,7 @@ def get_config(override_name=None):
             except KeyError:
                 params[key] = group
             except AttributeError:
-                pass # Ignore keys that are not dictionaries
+                pass  # Ignore keys that are not dictionaries
 
     ### Configuration input checks
     # For convenience
@@ -54,10 +56,15 @@ def get_config(override_name=None):
     _check_leadtime(params)
 
     # PGM-related checks
-    if ("pgm" in data.get("importer", "").lower() and
-            not params["output_options"].get("use_old_format", False)):
-        raise ValueError(("Cannot write ODIM-compliant output when input data is in .pgm format! "
-                         "Set 'output_options.use_old_format' to 'true'."))
+    if "pgm" in data.get("importer", "").lower() and not params["output_options"].get(
+        "use_old_format", False
+    ):
+        raise ValueError(
+            (
+                "Cannot write ODIM-compliant output when input data is in .pgm format! "
+                "Set 'output_options.use_old_format' to 'true'."
+            )
+        )
 
     # Nowcast-method specific input checks
     # TODO: Add checks for other pysteps nowcast methods
@@ -75,29 +82,47 @@ def get_config(override_name=None):
             ).format(d, n)
             raise ValueError(error_msg_timestep_conflict)
         # kmperpixel check
-        if ncopt.get("kmperpixel", None) is None and ncopt.get("vel_pert_method") in {"bps"}:
+        if ncopt.get("kmperpixel", None) is None and ncopt.get("vel_pert_method") in {
+            "bps"
+        }:
             raise ValueError("Configuration error: kmperpixel is required")
 
     # Expand ~ in paths, if any
-    params["data_source"]["root_path"] = Path(params["data_source"]["root_path"]).expanduser()
-    params["output_options"]["path"] = Path(params["output_options"]["path"]).expanduser()
+    params["data_source"]["root_path"] = Path(
+        params["data_source"]["root_path"]
+    ).expanduser()
+    params["output_options"]["path"] = Path(
+        params["output_options"]["path"]
+    ).expanduser()
     params["logging"]["log_folder"] = Path(params["logging"]["log_folder"]).expanduser()
-    params["callback_options"]["tmp_folder"] = Path(params["callback_options"]["tmp_folder"]).expanduser()
+    params["callback_options"]["tmp_folder"] = Path(
+        params["callback_options"]["tmp_folder"]
+    ).expanduser()
 
     # Resolve relative paths, if any
-    params["callback_options"]["tmp_folder"] = params["output_options"]["path"].joinpath(
-        params["callback_options"]["tmp_folder"]
-    )
+    params["callback_options"]["tmp_folder"] = params["output_options"][
+        "path"
+    ].joinpath(params["callback_options"]["tmp_folder"])
 
     return params
+
 
 def _check_datasource(ds):
     """Check config file for errors in data_source definition"""
     if not isinstance(ds, dict):
-        raise ValueError("Configuration error: mandatory option group 'data_source' is missing!")
+        raise ValueError(
+            "Configuration error: mandatory option group 'data_source' is missing!"
+        )
 
-    required_keys = ("root_path", "path_fmt", "fn_pattern", "fn_ext", "importer",
-                     "timestep", "importer_kwargs")  # importer_kwargs may be empty
+    required_keys = (
+        "root_path",
+        "path_fmt",
+        "fn_pattern",
+        "fn_ext",
+        "importer",
+        "timestep",
+        "importer_kwargs",
+    )  # importer_kwargs may be empty
     # Go through all keys and display all missing keys
     missing = []
     for key in required_keys:
@@ -105,13 +130,22 @@ def _check_datasource(ds):
         if value is None:
             missing.append(key)
     if missing:
-        raise ValueError("Following required parameters are missing from data_source group: {}".format(missing))
+        raise ValueError(
+            "Following required parameters are missing from data_source group: {}".format(
+                missing
+            )
+        )
     # Type checks
     if not isinstance(ds.get("timestep"), int):
-        raise TypeError("Configuration error in data_sources: timestep must be an integer")
+        raise TypeError(
+            "Configuration error in data_sources: timestep must be an integer"
+        )
     if not isinstance(ds.get("importer_kwargs"), dict):
-        raise TypeError('Configuration error in data_sources: importer_kwargs must be an object '
-                        '({"key": value}). It can be empty.')
+        raise TypeError(
+            "Configuration error in data_sources: importer_kwargs must be an object "
+            '({"key": value}). It can be empty.'
+        )
+
 
 # FIXME: Logic could be simplified
 def _check_leadtime(params):
@@ -125,8 +159,10 @@ def _check_leadtime(params):
     # leadtimes is not given, but timestep and maximum is
     if leadtimes is None:
         if None in (max_leadtime, nowcast_timestep):
-            raise ValueError("Need to set both 'max_leadtime' and 'nowcast_timestep' if 'leadtimes'"
-                             " is not given")
+            raise ValueError(
+                "Need to set both 'max_leadtime' and 'nowcast_timestep' if 'leadtimes'"
+                " is not given"
+            )
         leadtimes = int(max_leadtime / nowcast_timestep)
         runopt["leadtimes"] = leadtimes
 
@@ -136,15 +172,19 @@ def _check_leadtime(params):
         # else generate a list
         if nowcast_timestep is not None and nowcast_timestep != input_timestep:
             # if given as list, "1" in leadtimes means 1*input_timestep minutes (if given as a single number 1 means 1 minute)
-            #runopt["leadtimes"] = [nowcast_timestep + i*nowcast_timestep for i in range(leadtimes)]
-            runopt["leadtimes"] = [nowcast_timestep + i*(nowcast_timestep/input_timestep) for i in range(leadtimes)]
-            
+            # runopt["leadtimes"] = [nowcast_timestep + i*nowcast_timestep for i in range(leadtimes)]
+            runopt["leadtimes"] = [
+                nowcast_timestep + i * (nowcast_timestep / input_timestep)
+                for i in range(leadtimes)
+            ]
+
     # if leadtimes is a list, pass (might need to include a check for valid values within list)
     elif isinstance(leadtimes, (list, tuple)):
         pass
     else:
         raise ValueError("Cannot figure out leadtimes")
     # else raise error?
+
 
 def get_params(name):
     """Utility function for easier access to wanted parametrizations.
@@ -174,13 +214,18 @@ def get_params(name):
         with open(cfname, "r") as f:
             params = json.load(f)
     except FileNotFoundError as exc:
-        file_missing_msg = ("Cannot find requested config '{}'! Are the filename and path correct?"
-                            "\n{}").format(name.stem, cfname)
+        file_missing_msg = (
+            "Cannot find requested config '{}'! Are the filename and path correct?"
+            "\n{}"
+        ).format(name.stem, cfname)
         raise OSError(file_missing_msg) from exc
     except JSONDecodeError as exc:
-        raise RuntimeError("Could not decode config file. Is it valid JSON file?") from exc
+        raise RuntimeError(
+            "Could not decode config file. Is it valid JSON file?"
+        ) from exc
 
     return params
+
 
 def dump_params_to_json(params, config_name):
     """Utility function for dumping the used parametrisations to a new config file.
@@ -194,15 +239,18 @@ def dump_params_to_json(params, config_name):
     with open(f"config/{config_name}.json", "w") as f:
         json.dump(params, f, indent=2)
 
+
 def dump_defaults():
     """Utility function for generating a configuration file with default values.
     Useful for creating new configurations using Python shell."""
     dump_params_to_json(defaults, "defaults")
 
+
 def dump_empty():
     """Utility function for generating an empty configuration file."""
     empty = {key: {} for key in defaults.keys()}
     dump_params_to_json(empty, "empty")
+
 
 # Default parameters for PPN, other dictionaries should override these parameters
 # using dict.update() method.
@@ -213,19 +261,13 @@ defaults = {
         "zr_b": 1.53,
         "rain_threshold": 8,  # In data units
     },
-
-    "data_source": {
-    },
-
+    "data_source": {},
     "logging": {
         "write_log": False,
         "log_level": logging.INFO,
         "log_folder": "/tmp",
     },
-
-    "motion_options": {
-    },
-
+    "motion_options": {},
     "nowcast_options": {
         # Default to the nowcast method defaults
         # n_ens_members = 24,
@@ -238,21 +280,18 @@ defaults = {
             "p_perp": [2.21722634, 0.32359621, -2.57402761],
         },
         "domain": "spectral",  # pysteps default
-
-        "num_workers": 6, # pysteps defaults to 1, we want more.
+        "num_workers": 6,  # pysteps defaults to 1, we want more.
         "seed": None,  # pysteps default
-
         # Previously hardcoded values
         "extrap_method": "semilagrangian",
         "noise_method": "nonparametric",
         "ar_order": 2,
         "mask_method": "incremental",
         # Required parameters that need to be calculated or defined
-        #"kmperpixel": # required for motion perturbation method (bps)
-        #"timestep": # "Timestep" of MOTION VECTOR, get from input data
+        # "kmperpixel": # required for motion perturbation method (bps)
+        # "timestep": # "Timestep" of MOTION VECTOR, get from input data
         # "precip_thr":  # must be in decibel units...
     },
-
     "output_options": {
         #
         "path": "/tmp",
@@ -262,26 +301,25 @@ defaults = {
         "store_ensemble": True,
         "store_deterministic": True,
         #
-        "as_quantity": None, # None == same as input. Other valids: DBZH, RATE (see ODIM standard)
+        "as_quantity": None,  # None == same as input. Other valids: DBZH, RATE (see ODIM standard)
         "convert_to_dtype": None,  # None == same as input. Otherwise provide a valid string for numpy.dtype()
-        #"scaler": 10, # Deprecated
-        #"scale_zero": "auto", # Deprecated
+        # "scaler": 10, # Deprecated
+        # "scale_zero": "auto", # Deprecated
         "gain": 0.1,
         "offset": -32,  # "auto" for data minimum
         # "input" values are encoded, numbers given here are not
-        "set_undetect_value_to": "input", # a number or "input". input == read from input (units converted if needed)
+        "set_undetect_value_to": "input",  # a number or "input". input == read from input (units converted if needed)
         "set_nodata_value_to": "default",  # A number, "default", "max_int", "min_int", or "nan" (floats only).
         #
-        "write_leadtimes_separately": False, # Store each leadtime after calculating it instead of everything at the end
+        "write_leadtimes_separately": False,  # Store each leadtime after calculating it instead of everything at the end
         "write_asap": True,
         "use_old_format": False,  # Remove when postprocessing can use ODIM format
     },
-
     "run_options": {
         "leadtimes": 12,  # int = number of timesteps, list of floats = forecast for these lead times
         # if leadtimes is not a list and nowcast_timestep != input timestep, use these to make it into one
-        "nowcast_timestep": None, # optional, default to input timestep
-        "max_leadtime": 60, # optional, used only if "leadtimes" is None
+        "nowcast_timestep": None,  # optional, default to input timestep
+        "max_leadtime": 60,  # optional, used only if "leadtimes" is None
         # What is calculated
         "run_deterministic": True,
         "run_ensemble": True,
@@ -292,21 +330,20 @@ defaults = {
         "motion_method": "lucaskanade",
         "nowcast_method": "steps",
         "deterministic_method": "extrapolation",
-
         #
         "forecast_as_quantity": "DBZH",  # Input data is converted to this before nowcasting
         "steps_set_no_rain_to_value": -10,  # In forecast quantity units
     },
-
     # Used when writing ensemble nowcasts after each timestep with callback function
     "callback_options": {
         "tmp_folder": "tmp",  # relative to output_options.path (or absolute path)
-    }
+    },
 }
 
 # Test cases
-if __name__ == '__main__':
+if __name__ == "__main__":
     from pprint import pprint
+
     # Test custom parameter updating
     print("Updating default parameters with custom config")
     cfg = get_config("test/customised")

--- a/fmippn/ppn_config.py
+++ b/fmippn/ppn_config.py
@@ -271,22 +271,27 @@ defaults = {
     "nowcast_options": {
         # Default to the nowcast method defaults
         # n_ens_members = 24,
-        "n_cascade_levels": 6,  # pysteps default for steps
-        "fft_method": "pyfftw",
+        "method_specific_options": {
+            "steps": {
+                "n_cascade_levels": 6,  # pysteps default for STEPS
+                "fft_method": "pyfftw",
+                "domain": "spectral",  # pysteps default
+                "noise_method": "nonparametric",
+                "ar_order": 2,
+                "mask_method": "incremental",
+            },
+            "linda": {},
+        },
         "vel_pert_method": "bps",  # pysteps default, requires kmperpixel to be set
         "vel_pert_kwargs": {
             # lucaskanade/fmi values given in pysteps.nowcasts.steps.forecast() method documentation
             "p_par": [2.20837526, 0.33887032, -2.48995355],
             "p_perp": [2.21722634, 0.32359621, -2.57402761],
         },
-        "domain": "spectral",  # pysteps default
         "num_workers": 6,  # pysteps defaults to 1, we want more.
         "seed": None,  # pysteps default
         # Previously hardcoded values
         "extrap_method": "semilagrangian",
-        "noise_method": "nonparametric",
-        "ar_order": 2,
-        "mask_method": "incremental",
         # Required parameters that need to be calculated or defined
         # "kmperpixel": # required for motion perturbation method (bps)
         # "timestep": # "Timestep" of MOTION VECTOR, get from input data

--- a/fmippn/ppn_logger.py
+++ b/fmippn/ppn_logger.py
@@ -5,12 +5,13 @@ import logging
 _logger = None
 
 _logger_severity = {
-    'critical': logging.CRITICAL,
-    'debug': logging.DEBUG,
-    'error': logging.ERROR,
-    'info': logging.INFO,
-    'warning': logging.WARNING,
+    "critical": logging.CRITICAL,
+    "debug": logging.DEBUG,
+    "error": logging.ERROR,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
 }
+
 
 def config_logging(fname, level=logging.INFO, datefmt="%Y-%m-%d %H:%M:%S"):
     """Setup logger object using logging.basicConfig.
@@ -22,8 +23,7 @@ def config_logging(fname, level=logging.INFO, datefmt="%Y-%m-%d %H:%M:%S"):
     """
     global _logger
     formatter = logging.Formatter(
-        fmt="%(asctime)s (%(name)s) %(levelname)s: %(message)s",
-        datefmt=datefmt
+        fmt="%(asctime)s (%(name)s) %(levelname)s: %(message)s", datefmt=datefmt
     )
     handler = logging.FileHandler(fname)
     handler.setFormatter(formatter)
@@ -31,13 +31,16 @@ def config_logging(fname, level=logging.INFO, datefmt="%Y-%m-%d %H:%M:%S"):
     _logger.addHandler(handler)
     _logger.setLevel(level)
 
+
 def write_to_log(level, msg, *args, **kwargs):
     """Write `msg` at logging level `level` to log.
     args and kwargs are passed to logging functions.
     """
     if _logger is None:
-        raise RuntimeError("Tried to write to log before logging was configured! "
-                           "Call 'configure_logging' first.")
+        raise RuntimeError(
+            "Tried to write to log before logging was configured! "
+            "Call 'configure_logging' first."
+        )
     lvl = level.lower()
     severity = _logger_severity.get(lvl)
     if severity is None:

--- a/fmippn/run_ppn.py
+++ b/fmippn/run_ppn.py
@@ -22,8 +22,9 @@ def get_input_arguments():
     # Add more options if necessary
     parser = argparse.ArgumentParser(description="Command line interface for FMI-PPN")
     parser.add_argument("-c", "--config", help="Select configuration settings")
-    parser.add_argument("-t", "--timestamp", help="Nowcast initialization time",
-                        metavar="YYYYMMDDHHMM")
+    parser.add_argument(
+        "-t", "--timestamp", help="Nowcast initialization time", metavar="YYYYMMDDHHMM"
+    )
 
     return vars(parser.parse_args())
 


### PR DESCRIPTION
Update pysteps version to 1.7 and add functionality to run LINDA model.

To run LINDA, we need to refactor config parameters for nowcast models, which leads to changes e.g. in writing output file metadata.

Also:
* change rain rate threshold calculation to assume Z values are given in dBZ
* set image metadata in output HDF5 to view as images in hdfview
* run syntax formatting (black with default settings) on all files (which causes a lot of whitespace changes)